### PR TITLE
Fixes hot reload when running Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,7 @@ import {getOptions} from 'loader-utils'
  * @returns {string} the code needed to handle the riot hot reload
  */
 function hotReload(path) {
-  if (process.platform === 'win32') {
-    path = path.replace(/\\/g, '\\\\')
-  }
+  path = path.replace(/\\/g, '\\\\')
   return `;(() => {
   if (module.hot) {
     const hotReload = require('@riotjs/hot-reload').default

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ import {getOptions} from 'loader-utils'
  * @returns {string} the code needed to handle the riot hot reload
  */
 function hotReload(path) {
+  if ( process.platform === "win32" ) {
+    path = path.replace(/\\/g, '\\\\');
+  }
   return `;(() => {
   if (module.hot) {
     const hotReload = require('@riotjs/hot-reload').default

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import {getOptions} from 'loader-utils'
  * @returns {string} the code needed to handle the riot hot reload
  */
 function hotReload(path) {
-  if ( process.platform === "win32" ) {
-    path = path.replace(/\\/g, '\\\\');
+  if (process.platform === 'win32') {
+    path = path.replace(/\\/g, '\\\\')
   }
   return `;(() => {
   if (module.hot) {


### PR DESCRIPTION
Seems to be an issue since Windows uses the backslash character as folder separator.