### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ And afterward webpack will be able to automatically reload your Riot.js componen
 
 ## Examples
 
-Please check the following exapmles to see how it's easy to configure webpack with riot:
+Please check the following examples to see how it's easy to configure webpack with riot:
 - [Lazy routes](https://github.com/riot/examples/tree/gh-pages/lazy-routes)
 - [SSR](https://github.com/riot/examples/tree/gh-pages/ssr)
 


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'polyfills'. Here is your error report:
 https://triplechecker.com/s/mRVkFQ/riot.js.org

Hope it's helpful!
